### PR TITLE
Correct the timeout error message

### DIFF
--- a/lib/testswarm.js
+++ b/lib/testswarm.js
@@ -89,7 +89,7 @@ function pollJobStatus( testswarm, options, jobInfo, callback ) {
 			return !isJobDone( data.job );
 		},
 		onTimeout: function( data ) {
-			callback( "Timed out after " + config.timeout + "ms", data.job );
+			callback( "Timed out after " + options.timeout + "ms", data.job );
 		},
 		onSuccess: function( data ) {
 			callback( null, data.job );


### PR DESCRIPTION
Previously, it would report undefined when a timeout occurred since it looks like the timout lives under `options`, not `config`
