### PR TITLE
Fix request form array syntax after a recent update

### DIFF
--- a/lib/testswarm.js
+++ b/lib/testswarm.js
@@ -191,7 +191,7 @@ TestSwarm.prototype.auth = function( auth ) {
  * @emits addjob-ready ( {boolean} passsed, {Object} results )
  */
 TestSwarm.prototype.addjob = function( options, callback ) {
-	var testswarm, missing, runNames, runUrls;
+	var testswarm, missing, runNames, runUrls, browserSets;
 
 	testswarm = this;
 	missing = keysMissingFrom( options, [ "name", "runs", "browserSets" ] );
@@ -211,15 +211,19 @@ TestSwarm.prototype.addjob = function( options, callback ) {
 		return options.runs[name];
 	});
 
+	browserSets = Array.isArray( options.browserSets ) ?
+		options.browserSets :
+		[ options.browserSets ];
+
 	request.post({
 		url: testswarm.config.url + "/api.php",
 		form: authenticateRequest( testswarm, {
 			action: "addjob",
 			jobName: options.name,
 			runMax: options.runMax,
-			"runNames[]": runNames,
-			"runUrls[]": runUrls,
-			"browserSets[]": options.browserSets
+			runNames: runNames,
+			runUrls: runUrls,
+			browserSets: browserSets
 		})
 	}, function( err, resp, body ) {
 		var data, jobInfo;


### PR DESCRIPTION
The recent `request` update broke jQuery Migrate TestSwarm setup; apparently, the syntax used to pass form data changed and the suffix `[]` shouldn't be used for keys. What gets in form data on `master`:
```
array (
  'action' => 'addjob',
  'jobName' => 'Commit <a href=\'https://github.com/jquery/jquery-migrate/commit/COMMIT_HASH\'></a>',
  'runMax' => '5',
  'runNames' => 
  array (
    0 => 
    array (
      0 => 'dev+git',
    ),
    1 => 
    array (
      1 => 'min+git.min',
    ),
    2 => 
    array (
      2 => 'dev+git.slim',
    ),
    3 => 
    array (
      3 => 'min+git.slim.min',
    ),
  ),
  'runUrls' => 
  array (
    0 => 
    array (
      0 => 'http://jquery-migrate.l//test/index.html?plugin=dev&jquery=git',
    ),
    1 => 
    array (
      1 => 'http://jquery-migrate.l//test/index.html?plugin=min&jquery=git.min',
    ),
    2 => 
    array (
      2 => 'http://jquery-migrate.l//test/index.html?plugin=dev&jquery=git.slim',
    ),
    3 => 
    array (
      3 => 'http://jquery-migrate.l//test/index.html?plugin=min&jquery=git.slim.min',
    ),
  ),
  'browserSets' => 
  array (
    0 => 'jquery',
  ),
  'authID' => 'jquerymigrate',
  'authToken' => 'XXX',
)
```

What gets there after applying changes from this PR:
```
array (
  'action' => 'addjob',
  'jobName' => 'Commit <a href=\'https://github.com/jquery/jquery-migrate/commit/COMMIT_HASH\'></a>',
  'runMax' => '5',
  'runNames' => 
  array (
    0 => 'dev+git',
    1 => 'min+git.min',
    2 => 'dev+git.slim',
    3 => 'min+git.slim.min',
  ),
  'runUrls' => 
  array (
    0 => 'http://jquery-migrate.l//test/index.html?plugin=dev&jquery=git',
    1 => 'http://jquery-migrate.l//test/index.html?plugin=min&jquery=git.min',
    2 => 'http://jquery-migrate.l//test/index.html?plugin=dev&jquery=git.slim',
    3 => 'http://jquery-migrate.l//test/index.html?plugin=min&jquery=git.slim.min',
  ),
  'browserSets' => 
  array (
    0 => 'jquery',
  ),
  'authID' => 'jquerymigrate',
  'authToken' => 'XXX',
)
```